### PR TITLE
Use `norpc::async_trait` in example of doc/readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ trait HelloWorld {
    fn hello(s: String) -> String;
 }
 struct HelloWorldApp;
-#[async_trait::async_trait]
+#[norpc::async_trait]
 impl HelloWorld for HelloWorldApp {
    async fn hello(&self, s: String) -> String {
        format!("Hello, {}", s)

--- a/norpc/src/lib.rs
+++ b/norpc/src/lib.rs
@@ -8,7 +8,7 @@
 //!    fn hello(s: String) -> String;
 //! }
 //! struct HelloWorldApp;
-//! #[async_trait::async_trait]
+//! #[norpc::async_trait]
 //! impl HelloWorld for HelloWorldApp {
 //!    async fn hello(&self, s: String) -> String {
 //!        format!("Hello, {}", s)


### PR DESCRIPTION
`async_trait` is re-exported in `norpc`.
If we only add `norpc` dependency in our project, the proposed code won't build.

It's seems better to me, to write `norpc::async_trait` in doc and readme, as it is done in example/async_std_runtime.rs
